### PR TITLE
fix soupsieve import

### DIFF
--- a/commoncore/beautifulsoup/bs4/element.py
+++ b/commoncore/beautifulsoup/bs4/element.py
@@ -9,7 +9,7 @@ import re
 import sys
 import warnings
 try:
-    from commoncore.beautifulsoup.bs4 import soupsieve
+    from commoncore.beautifulsoup.bs4.soupsieve import * as soupsieve
 except ImportError as e:
     soupsieve = None
     warnings.warn(


### PR DESCRIPTION
before my log went crazy with ".kodi/addons/plugin.git.browser/commoncore/beautifulsoup/bs4/element.py:16: UserWarning: The soupsieve package is not installed. CSS selectors cannot be used." messages