### PR TITLE
Use proper query syntax for GitHub requests

### DIFF
--- a/addon.py
+++ b/addon.py
@@ -25,7 +25,7 @@ def main():
 	kodi.add_menu_item({'mode': 'search_menu', 'type': "repository", 'title': "Search by GitHub Repository Title"}, {'title': "Search by GitHub Repository Title [COLOR red](Advanced)[/COLOR]"}, icon='repository.png')
 	kodi.add_menu_item({'mode': 'search_menu', 'type': "addonid",'title': "Search by Addon ID"}, {'title': "Search by Addon ID [COLOR red](Advanced)[/COLOR]"}, icon='addonid.png')
 	kodi.add_menu_item({'mode': 'feed_menu'}, {'title': "Search Feeds"}, icon='search_feeds.png')
-	kodi.add_menu_item({'mode': 'installer_menu'}, {'title': "Batch Installers"}, icon='batch_installer.png') 
+	kodi.add_menu_item({'mode': 'installer_menu'}, {'title': "Batch Installers"}, icon='batch_installer.png')
 	kodi.add_menu_item({'mode': 'about'}, {'title': "About GitHub Installer"}, icon='about.png')
 	kodi.add_menu_item({'mode': 'settings_menu'}, {'title': "Tools and Settings"}, icon='settings.png')
 
@@ -34,7 +34,7 @@ def settings_menu():
 	kodi.add_menu_item({'mode': 'dependency_search'}, {'title': "Search for missing dependencies"}, icon='search_failed.png')
 	kodi.add_menu_item({'mode': 'update_addons'}, {'title': "Check for Updates [COLOR red](Advanced)[/COLOR]"}, icon='update.png', visible=kodi.get_setting('enable_updates') == 'true')
 	kodi.add_menu_item({'mode': 'addon_settings'}, {'title': "Addon Settings"}, icon='settings.png')
-	
+
 @kodi.register('search_menu')
 def search_menu():
 	menu = kodi.context_menu()
@@ -59,14 +59,14 @@ def dependency_search():
 				DB.commit()
 				continue
 			kodi.add_menu_item({'mode': 'search', 'type': "addonid",'query': result[0]}, {'title': result[0]}, icon='addonid.png')
-		
+
 @kodi.register('search')
 def search():
 	q = kodi.arg('query') if kodi.arg('query') else kodi.dialog_input('Search GitHub')
 	if q in [None, False, '']: return False
 	DB.execute('REPLACE INTO search_history(search_type, query) VALUES(?,?)', [kodi.arg('type'), q])
 	DB.commit()
-	
+
 	@dispatcher.register('username')
 	def username():
 		rtype = 'api'
@@ -82,10 +82,10 @@ def search():
 				kodi.add_menu_item({'mode': 'install_feed', "url": url}, {'title': r['name'], 'display': r['display']}, menu=menu, icon='null')
 			elif r['is_installer']:
 				r['display'] = "[COLOR orange]%s[/COLOR]" % r['name']
-				kodi.add_menu_item({'mode': 'install_batch', "url": url}, {'title': r['name'], 'display': r['display']}, menu=menu, icon='null')	
+				kodi.add_menu_item({'mode': 'install_batch', "url": url}, {'title': r['name'], 'display': r['display']}, menu=menu, icon='null')
 			else:
 				kodi.add_menu_item({'mode': 'github_install', "url": url, "user": q, "file": r['name'], "full_name": "%s/%s" % (q, r['repository']['name'])}, {'title': r['name']}, menu=menu, icon='null')
-	
+
 	@dispatcher.register('repository')
 	def repository():
 		rtype = 'api'
@@ -105,17 +105,17 @@ def search():
 					kodi.add_menu_item({'mode': 'install_feed', "url": url}, {'title': r['name']}, menu=menu, icon='null')
 				elif r['is_installer']:
 					r['display'] = "[COLOR orange]%s[/COLOR]" % r['name']
-					kodi.add_menu_item({'mode': 'install_batch', "url": url}, {'title': r['name'], 'display': r['display']}, menu=menu, icon='null')	
+					kodi.add_menu_item({'mode': 'install_batch', "url": url}, {'title': r['name'], 'display': r['display']}, menu=menu, icon='null')
 				else:
 					kodi.add_menu_item({'mode': 'github_install', "url": url, "user": q, "file": r['name'], "full_name": "%s/%s" % (q, r['repository']['name'])}, {'title': r['name']}, menu=menu, icon='null')
-	
+
 	@dispatcher.register('addonid')
 	def addonid():
 		rtype = 'api'
 		results = github.search(q, 'id')
 		if results is None: return
 		results.sort(key=lambda x:github.version_sort(x['name']), reverse=True)
-			
+
 		for i in results:
 			menu = kodi.context_menu()
 			r = i['repository']
@@ -135,7 +135,7 @@ def search_filter():
 		display[index] = kodi.format_color(display[index], 'yellow')
 	else:
 		display[0] = kodi.format_color(display[0], 'yellow')
-		
+
 	c = kodi.dialog_select("Filter Results by:", display)
 	if c is not False:
 		if c is 0:
@@ -150,7 +150,7 @@ def feed_menu():
 	feeds = DB.query_assoc("SELECT feed_id, name, url, enabled FROM feed_subscriptions")
 	for feed in feeds:
 		menu = kodi.ContextMenu()
-		
+
 		name = feed['name'] if feed['name'] else feed['url']
 		if not feed['enabled']:
 			title = "[COLOR darkred]%s[/COLOR]" % name
@@ -162,7 +162,7 @@ def feed_menu():
 def installer_menu():
 	kodi.add_menu_item({'mode': 'browse_local'}, {'title': "*** Install From Local File ***"}, icon='install_batch_local.png')
 	#kodi.add_menu_item({'mode': 'search', 'query': 'gitbrowser.installer', 'type': 'addonid'}, {'title': "*** Search for Batch Installers ***"}, icon='null')
-	
+
 
 @kodi.register(['install_feed', 'install_local_feed'], False)
 def install_feed():
@@ -174,7 +174,7 @@ def install_feed():
 		if not github.re_feed.search(url): return
 		xml = github.install_feed(url, True)
 	if not kodi.dialog_confirm('Install Feed?', "Click YES to proceed."): return
-	
+
 	try:
 		for f in xml.findAll('feeds'):
 			name = f.find('name').text
@@ -185,7 +185,7 @@ def install_feed():
 		kodi.set_setting('installed_feeds', str(count[0][0]))
 		kodi.notify("Install Complete",'Feed Installed')
 	except:
-		kodi.notify("Install failed",'Invalid Format.')	
+		kodi.notify("Install failed",'Invalid Format.')
 
 def feed_count():
 	try:
@@ -211,11 +211,11 @@ def install_batch():
 	installed_list = []
 	failed_list = []
 	count = 0
-	for a in xml.findAll('addon'): 
-		count +=1 
+	for a in xml.findAll('addon'):
+		count +=1
 	PB = kodi.ProgressBar()
 	PB.new('Batch Installer - Progress', count)
-	
+
 	for a in xml.findAll('addon'):
 		addon_id = a.find('addon_id')
 		username = a.find('username')
@@ -246,7 +246,7 @@ def install_batch():
 			destination = destination.text
 			if not kodi.vfs.exists(destination): kodi.vfs.mkdir(destination, True)
 			kodi.vfs.write_file(kodi.vfs.join(destination, source), zip_ref.read(config_dir + '/' + source))
-	
+
 	# Now look for individual setting key and value pairs
 	# Set them as instructed
 	settings= xml.find('settings')
@@ -264,7 +264,7 @@ def install_batch():
 		for cmd in builtins.findAll('command'):
 			cmd = cmd.text
 			kodi.run_command(cmd)
-			
+
 	jsonrpc= xml.find('jsonrpc')
 	if jsonrpc is not None:
 		from ast import literal_eval
@@ -288,8 +288,8 @@ def install_batch():
 			xbmc.executebuiltin('RestartApp')
 		else:
 			xbmc.executebuiltin('ShutDown')
-	
-	
+
+
 @kodi.register('new_feed')
 def new_feed():
 	url = kodi.dialog_input('Feed URL')
@@ -304,7 +304,7 @@ def delete_feed():
 	DB.execute("DELETE FROM feed_subscriptions WHERE feed_id=?", [kodi.arg('id')])
 	DB.commit()
 	kodi.refresh()
-	
+
 @kodi.register('list_feed')
 def feed_list():
 	from commoncore.baseapi import CACHABLE_API, EXPIRE_TIMES
@@ -319,10 +319,10 @@ def feed_list():
 			desc = r.find('description').text
 			title = "%s: %s" % (name, desc)
 			kodi.add_menu_item({'mode': 'search', 'type': 'username', 'query': username}, {'title': title, 'plot': desc}, icon='null')
-		kodi.eod()	
+		kodi.eod()
 	except Exception as e:
 		kodi.log(e)
-	
+
 @kodi.register('github_install', False)
 def github_install():
 	import re
@@ -369,7 +369,7 @@ def show_about():
 		text = kodi.vfs.read_file(path)
 		kodi.dialog_textbox('GitHub Browser Instructions', text)
 	else:
-		interval -= 1	
+		interval -= 1
 	kodi.set_setting('last_about', interval)
 
 @kodi.register('browse_repository', False)
@@ -388,7 +388,7 @@ def browse_repository():
 def history_delete():
 	if not kodi.arg('id'): return
 	DB.execute("DELETE FROM search_history WHERE search_id=?", [kodi.arg('id')])
-	DB.commit()	
+	DB.commit()
 	kodi.refresh()
 
 @kodi.register('update_addons', False)
@@ -399,5 +399,5 @@ def update_addons():
 		c = kodi.dialog_confirm("Confirm Update", "Check for updates", yes="Update", no="Cancel")
 		if not c: return
 	github_installer.update_addons(quiet)
-	
+
 if __name__ == '__main__': kodi.run()

--- a/github/__init__.py
+++ b/github/__init__.py
@@ -31,6 +31,6 @@ for name in __github__:
 	else:
 		names = [x for x in mod.__dict__ if not x.startswith("_")]
 	globals().update({k: getattr(mod, k) for k in names})
-	
+
 from commoncore import kodi
 from commoncore.dispatcher import dispatcher

--- a/github/database.py
+++ b/github/database.py
@@ -20,7 +20,7 @@ from commoncore.database import SQLiteDatabase
 
 DB_TYPE = 'sqlite'
 DB_FILE = kodi.vfs.join(kodi.get_profile(), 'cache.db')
-	
+
 class DBI(SQLiteDatabase):
 	def _initialize(self):
 		self.connect()

--- a/github/downloader.py
+++ b/github/downloader.py
@@ -29,7 +29,7 @@ def format_status(cached, total, speed):
 	cached = kodi.format_size(cached)
 	total = kodi.format_size(total)
 	speed = kodi.format_size(speed, 'B/s')
-	return	 "%s of %s at %s" % (cached, total, speed) 
+	return	 "%s of %s at %s" % (cached, total, speed)
 
 def test_url(url):
 	r = requests.head(url)
@@ -40,7 +40,7 @@ def download(url, addon_id, destination, unzip=False, quiet=False):
 	filename = addon_id + '.zip'
 	r = requests.get(url, stream=True)
 	kodi.log("Download: %s" % url)
-	
+
 	if r.status_code == requests.codes.ok:
 		temp_file = kodi.vfs.join(kodi.get_profile(), "downloads")
 		if not kodi.vfs.exists(temp_file): kodi.vfs.mkdir(temp_file, recursive=True)
@@ -75,7 +75,7 @@ def download(url, addon_id, destination, unzip=False, quiet=False):
 					if not quiet:
 						percent = int(cached_bytes * 100 / total_bytes)
 						pb.update(percent, "Downloading",filename, format_status(cached_bytes, total_bytes, bs))
-		
+
 		if not quiet: pb.close()
 		if unzip:
 			if is_64bit:
@@ -103,4 +103,3 @@ def download(url, addon_id, destination, unzip=False, quiet=False):
 		kodi.close_busy_dialog()
 		raise downloaderException(r.status_code)
 	return version
-	

--- a/github/github_api.py
+++ b/github/github_api.py
@@ -231,10 +231,10 @@ def search(q, method=False):
 	if method=='user':
 		return GH.request("/search/repositories", query={"per_page": page_limit, "q": "user:%s" % q}, cache_limit=EXPIRE_TIMES.HOUR)
 	elif method=='title':
-		return GH.request("/search/repositories", query={"per_page": page_limit, "q": "in:name+%s" % q}, cache_limit=EXPIRE_TIMES.HOUR)
+		return GH.request("/search/repositories", query={"per_page": page_limit, "q": "in:name %s" % q}, cache_limit=EXPIRE_TIMES.HOUR)
 	elif method == 'id':
 		results = []
-		temp = GH.request("/search/code", query={"per_page": page_limit, "q": "in:path+%s.zip" % q, "access_token": get_token()}, cache_limit=EXPIRE_TIMES.HOUR)
+		temp = GH.request("/search/code", query={"per_page": page_limit, "q": "in:path %s.zip" % q, "access_token": get_token()}, cache_limit=EXPIRE_TIMES.HOUR)
 		for t in temp['items']:
 			if re_version.search(t['name']): results.append(t)
 		return results
@@ -252,14 +252,14 @@ def find_zips(user, repo=None):
 	else:
 		q = '*.zip'
 	if repo is None:
-		results = limit_versions(GH.request("/search/code", query={"per_page": page_limit, "q":"user:%s+filename:%s" % (user, q)}, cache_limit=EXPIRE_TIMES.HOUR))
+		results = limit_versions(GH.request("/search/code", query={"per_page": page_limit, "q":"user:%s filename:%s" % (user, q)}, cache_limit=EXPIRE_TIMES.HOUR))
 	else:
-		results = limit_versions(GH.request("/search/code", query={"per_page": page_limit, "q":"user:%s+repo:%s+filename:%s" % (user, repo, q)}, cache_limit=EXPIRE_TIMES.HOUR))
+		results = limit_versions(GH.request("/search/code", query={"per_page": page_limit, "q":"user:%s repo:%s filename:%s" % (user, repo, q)}, cache_limit=EXPIRE_TIMES.HOUR))
 	return results
 
 def find_zip(user, addon_id):
 	results = []
-	response = GH.request("/search/code", query={"q": "user:%s+filename:%s*.zip" % (user, addon_id)}, cache_limit=EXPIRE_TIMES.HOUR)
+	response = GH.request("/search/code", query={"q": "user:%s filename:%s*.zip" % (user, addon_id)}, cache_limit=EXPIRE_TIMES.HOUR)
 	if response is None: return False, False, False
 	if response['total_count'] > 0:
 		test = re.compile("%s(-.+\.zip|\.zip)$" % addon_id, re.IGNORECASE)

--- a/github/github_api.py
+++ b/github/github_api.py
@@ -29,7 +29,7 @@ try:
 	from urllib.parse import urlencode
 except ImportError:
 	from urllib import urlencode
-import github	
+import github
 from github import DB
 
 class githubException(Exception):
@@ -70,7 +70,7 @@ class GitHubAPI(CACHABLE_API):
 
 	def prepair_request(self):
 		kodi.sleep(random.randint(100, 250)) # random delay 50-250 ms
-	
+
 	def build_url(self, uri, query, append_base):
 		if append_base:
 			url = self.base_url + uri
@@ -108,7 +108,7 @@ class GitHubAPI(CACHABLE_API):
 			kodi.close_busy_dialog()
 			traceback.print_stack()
 			raise githubException("Status %s: %s" % (response.status_code, response.text))
-			
+
 	def process_response(self, url, response, cache_limit, request_args, request_kwargs):
 		if 'page' in request_kwargs['query']:
 			page = request_kwargs['query']['page'] + 1
@@ -176,13 +176,13 @@ def get_version_by_xml(xml):
 		addon = xml.find('addon')
 		version = addon['version']
 	except:
-		return False	
+		return False
 
 def version_sort(name):
 	v = re_version.search(name)
 	if v:
 		return LooseVersion(v.group(1))
-	else: 
+	else:
 		return LooseVersion('0.0.0')
 
 def sort_results(results, limit=False):
@@ -195,7 +195,7 @@ def sort_results(results, limit=False):
 			last = addon_id
 			final.append(a)
 		return final
-		
+
 	def sort_results(name):
 		index = SORT_ORDER.OTHER
 		version = get_version_by_name(name)
@@ -266,16 +266,16 @@ def find_zip(user, addon_id):
 		def sort_results(name):
 			version = get_version_by_name(name)
 			return LooseVersion(version)
-			
+
 		response['items'].sort(key=lambda k: sort_results(k['name']), reverse=True)
-		
+
 		for r in response['items']:
 			if test.match(r['name']):
 				url = get_download_url(r['repository']['full_name'], r['path'])
 				version = get_version_by_name(r['path'])
 				return url, r['name'], r['repository']['full_name'], version
 	return False, False, False, False
-			
+
 
 def browse_repository(url):
 	import requests
@@ -303,7 +303,7 @@ def install_feed(url, local=False):
 		from StringIO import StringIO as byte_reader
 	else:
 		from io import BytesIO as byte_reader
-		
+
 	from commoncore.beautifulsoup import BeautifulSoup
 	if local:
 			r = kodi.vfs.open(url, "r")

--- a/service.py
+++ b/service.py
@@ -27,22 +27,22 @@ class UpdateService():
 	update_interval = 86400	# every 24 hours
 	def update(self):
 		if enable_updates:
-			if not self.last_run or time.time() - self.last_run > self.update_interval:	
+			if not self.last_run or time.time() - self.last_run > self.update_interval:
 				self.last_run = time.time()
 				plugin_url = kodi.build_plugin_url({"mode": "update_addons", "quiet": "quiet"}, kodi.get_id())
 				kodi.execute_url(plugin_url)
-	
+
 	def start(self):
-		
-		enable_updates 
+
+		enable_updates
 		class Monitor(xbmc.Monitor):
 			def onSettingsChanged(self):
 				global enable_updates
 				enable_updates = kodi.get_setting('enable_updates') == 'true'
 		monitor = Monitor()
 		kodi.log("Service Starting...")
-		
-		
+
+
 		if is_depricated:
 			while not xbmc.abortRequested:
 				kodi.sleep(1000)
@@ -52,10 +52,10 @@ class UpdateService():
 				if monitor.waitForAbort(10):
 					break
 				self.update()
-				
+
 		self.shutdown()
-	
-	
+
+
 	def shutdown(self):
 		kodi.log("Service Stopping...")
 


### PR DESCRIPTION
The [PyGithub](https://github.com/PyGithub/PyGithub) library percent-encodes all request query parameters. GitHub's V3 API either wants queries using no encoding and pluses to separate words, like `"?q=repo:octocat/Spoon-Knife+example"`, or queries using percent-encoding and spaces to separate words, like `"?q=repo%2Boctocat%3ASpoon-Knife%20example"`. Since we're forced to percent-encode, the query templates should use spaces, not pluses.

(Yes, this did function before, but it's less robust than with spaces.)

(The first commit just removes trailing whitespace in code this plugin owns (i.e. not commoncore). Look at the per-commit diff instead, or ignore whitespace in the combined diff.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tvaddonsco/plugin.git.browser/17)
<!-- Reviewable:end -->
